### PR TITLE
Allow passing null auth tokens to DDI-Client

### DIFF
--- a/hara-ddiclient-api/src/main/kotlin/org/eclipse/hara/ddiclient/api/HaraClientData.kt
+++ b/hara-ddiclient-api/src/main/kotlin/org/eclipse/hara/ddiclient/api/HaraClientData.kt
@@ -38,7 +38,7 @@ data class HaraClientData constructor(
         notEmpty(controllerId, "controllerId")
         notEmpty(serverUrl, "serverUrl")
         validUrl(serverUrl, "serverUrl")
-        check(!(gatewayToken.isNullOrBlank() && targetToken.isNullOrBlank())) {
+        check(!(gatewayToken?.isEmpty() == true && targetToken?.isEmpty() == true)) {
             "gatewayToken and targetToken cannot both be empty" }
     }
 

--- a/src/test/kotlin/org/eclipse/hara/ddiclient/integrationtest/DdiClientHttpRequestsTest.kt
+++ b/src/test/kotlin/org/eclipse/hara/ddiclient/integrationtest/DdiClientHttpRequestsTest.kt
@@ -108,7 +108,27 @@ class DdiClientHttpRequestsTest : AbstractHaraMessageTest() {
         }
     }
 
-    @Test(enabled = true, timeOut = 60_000, priority = 2)
+    @Test(enabled = true, priority = 2)
+    fun useNullTokensForAnonymousAuthorizationTest() {
+        runBlocking {
+            client = createClient(targetToken = null, gatewayToken = null)
+            enableTargetTokenInServer(false)
+            enableGatewayTokenInServer(false)
+
+            expectPollingOnlyMessage()
+            expectedServerResponses.apply {
+                OkHttpMessage(
+                    HttpURLConnection.HTTP_UNAUTHORIZED, null
+                ).also {
+                    add(it)
+                }
+            }
+
+            startSubTestTest(true)
+        }
+    }
+
+    @Test(enabled = true, timeOut = 60_000, priority = 3)
     fun useOnlyGatewayTokenTest() {
         runBlocking {
             client = createClient(targetToken = "")
@@ -153,7 +173,7 @@ class DdiClientHttpRequestsTest : AbstractHaraMessageTest() {
         startSubTestTest(true)
     }
 
-    @Test(enabled = true, timeOut = 60_000, priority = 3)
+    @Test(enabled = true, timeOut = 60_000, priority = 4)
     fun useOnlyTargetTokenTest() {
         runBlocking {
             client = createClient(gatewayToken = "")
@@ -199,7 +219,7 @@ class DdiClientHttpRequestsTest : AbstractHaraMessageTest() {
     }
 
 
-    @Test(enabled = true, timeOut = 60_000, priority = 4)
+    @Test(enabled = true, timeOut = 60_000, priority = 5)
     fun usingEmptyTargetTokenRequestShouldOnlyUseGatewayTokenTest() {
         runBlocking {
             client = createClient(targetToken = "")
@@ -220,7 +240,7 @@ class DdiClientHttpRequestsTest : AbstractHaraMessageTest() {
     }
 
 
-    @Test(enabled = true, timeOut = 60_000, priority = 5)
+    @Test(enabled = true, timeOut = 60_000, priority = 6)
     fun usingEmptyGatewayTokenRequestShouldOnlyUseTargetTokenTest() {
         runBlocking {
             enableTargetTokenInServer(true)
@@ -240,7 +260,7 @@ class DdiClientHttpRequestsTest : AbstractHaraMessageTest() {
         startSubTestTest(true)
     }
 
-    @Test(enabled = true, timeOut = 200_000, priority = 6)
+    @Test(enabled = true, timeOut = 200_000, priority = 7)
     fun providingBothTokensTest() {
         runBlocking {
             client = createClient()

--- a/src/test/kotlin/org/eclipse/hara/ddiclient/integrationtest/ForcePingTest.kt
+++ b/src/test/kotlin/org/eclipse/hara/ddiclient/integrationtest/ForcePingTest.kt
@@ -54,7 +54,7 @@ class ForcePingTest : AbstractHaraMessageTest() {
         }
     }
 
-    @Test(enabled = true, priority = 7, timeOut = 10_000, invocationCount = 1)
+    @Test(enabled = true, priority = 8, timeOut = 10_000, invocationCount = 1)
     fun forcePingShouldPollFromServerImmediatelyTest() {
         logCurrentFunctionName()
         runBlocking {
@@ -76,7 +76,7 @@ class ForcePingTest : AbstractHaraMessageTest() {
         }
     }
 
-    @Test(enabled = true, priority = 8, timeOut = 60_000, invocationCount = 1)
+    @Test(enabled = true, priority = 9, timeOut = 60_000, invocationCount = 1)
     fun timeIntervalBetweenEachForcePingCallShouldBe30SecondsTest() {
         logCurrentFunctionName()
         runBlocking {
@@ -109,7 +109,7 @@ class ForcePingTest : AbstractHaraMessageTest() {
         }
     }
 
-    @Test(enabled = true, priority = 9, timeOut = 10_000, invocationCount = 1)
+    @Test(enabled = true, priority = 10, timeOut = 10_000, invocationCount = 1)
     fun forcePingShouldReturnNoNewStateWhenTargetStateOnServerIsNotChanged() {
         logCurrentFunctionName()
         runBlocking {
@@ -132,7 +132,7 @@ class ForcePingTest : AbstractHaraMessageTest() {
         }
     }
 
-    @Test(enabled = true, priority = 10, timeOut = 150_000, invocationCount = 1)
+    @Test(enabled = true, priority = 11, timeOut = 150_000, invocationCount = 1)
     fun haraClientShouldReturnPollingStateAfterTheForcePingPollsUpdateFromServer() {
         logCurrentFunctionName()
         runBlocking {

--- a/src/test/kotlin/org/eclipse/hara/ddiclient/integrationtest/HawkbitDownloadOnlyDeploymentTest.kt
+++ b/src/test/kotlin/org/eclipse/hara/ddiclient/integrationtest/HawkbitDownloadOnlyDeploymentTest.kt
@@ -37,7 +37,7 @@ class HawkbitDownloadOnlyDeploymentTest : AbstractDeploymentTest() {
         setPollingTime("00:00:05")
     }
 
-    @Test(enabled = true, timeOut = 60_000, priority = 3)
+    @Test(enabled = true, timeOut = 60_000, priority = 14)
     fun testDownloadOnlyWhileWaitingForUpdateAuthorization() = runBlocking {
 
         reCreateTestTargetOnServer()

--- a/src/test/kotlin/org/eclipse/hara/ddiclient/integrationtest/HawkbitTimeForcedTest.kt
+++ b/src/test/kotlin/org/eclipse/hara/ddiclient/integrationtest/HawkbitTimeForcedTest.kt
@@ -39,7 +39,7 @@ class HawkbitTimeForcedTest : AbstractDeploymentTest() {
         setPollingTime("00:00:10")
     }
 
-    @Test(enabled = true, timeOut = 150_000, priority = 1)
+    @Test(enabled = true, timeOut = 150_000, priority = 12)
     fun testTimeForcedUpdateWhileWaitingForDownloadAuthorization() = runBlocking {
         reCreateTestTargetOnServer()
 
@@ -54,7 +54,7 @@ class HawkbitTimeForcedTest : AbstractDeploymentTest() {
 
     }
 
-    @Test(enabled = true, timeOut = 150_000, priority = 2)
+    @Test(enabled = true, timeOut = 150_000, priority = 13)
     fun testTimeForcedUpdateWhileWaitingForUpdateAuthorization() = runBlocking {
         reCreateTestTargetOnServer()
 


### PR DESCRIPTION
The testNg lib seems to run the tests in parallel which can affect the
test. Changed the order of the tests to prevent unexpected issues.
