### PR TITLE
Fix authorization request handling issue

### DIFF
--- a/.github/workflows/pipeline-build.yml
+++ b/.github/workflows/pipeline-build.yml
@@ -56,7 +56,7 @@ jobs:
           run: |
               if [[ "$RUNNER_OS" == "Windows" || ( "$RUNNER_OS" == "macOS" && ${{ github.event_name }} != 'pull_request' ) ]]; then
                   ./gradlew build -x test
-              elif [[ ${{ github.event_name }} == 'pull_request' && ${{ github.event.pull_request.head.repo.full_name != 'eclipse/hara-ddiclient' }} ]]; then
+              elif [[ ${{ github.event_name }} == 'pull_request' && ${{ github.event.pull_request.head.repo.full_name != 'eclipse-hara/hara-ddiclient' }} ]]; then
                   ./gradlew --info build
               else
                   ./gradlew --info build sonar

--- a/.github/workflows/pipeline-build.yml
+++ b/.github/workflows/pipeline-build.yml
@@ -11,7 +11,7 @@ jobs:
     build:
         strategy:
             matrix:
-                os: [ubuntu-latest, macos-latest, windows-latest]
+                os: [ubuntu-latest, macos-13, windows-latest]
         runs-on: ${{matrix.os}}
         steps:
         - name: Check repository
@@ -23,7 +23,7 @@ jobs:
 
         #Run only on macOS
         - name: Setup Docker
-          if: ${{ matrix.os == 'macos-latest' && github.event_name == 'pull_request' }}
+          if: ${{ matrix.os == 'macos-13' && github.event_name == 'pull_request' }}
           uses: better0fdead/actions-setup-docker@better0fdead/increase-timeout
 
         - name: Set up JDK 17


### PR DESCRIPTION
This commit addresses an issue where the client sends an immediate
authorization response upon receiving the authorization request, which
might get ignored, causing the client to be stuck waiting for the
authorization response.
From now on, the DownloadManager and UpdateManager actors will first
wait for the authorization response and then broadcast the event/state
regarding the authorization to the client.
