### PR TITLE
Fix hara client stopping crash #54

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ To build this project from source:
 ./gradlew assemble
 ```
 
-to build this project and run the tests (`docker 19.03.0+` and `docker-compose 1.27.0+` required):
+to build this project and run the tests (`docker compose v2` required):
 
 ```shell
 ./gradlew build

--- a/build.gradle
+++ b/build.gradle
@@ -242,7 +242,7 @@ task stopHawkbitServer() {
         if (!keep_test_container_alive) {
             exec {
                 workingDir 'docker/test/'
-                commandLine 'docker-compose', 'down'
+                commandLine 'docker', 'compose', 'down'
             }
         }
     }
@@ -253,14 +253,14 @@ task restartHawkbitServer() {
     doFirst {
         exec {
             workingDir 'docker/test/'
-            commandLine 'docker-compose', 'down'
+            commandLine 'docker', 'compose', 'down'
         }
     }
 
     doLast{
         exec {
             workingDir 'docker/test/'
-            commandLine 'docker-compose', 'up', '--detach'
+            commandLine 'docker', 'compose', 'up', '--detach'
         }
     }
 }

--- a/docker/README.md
+++ b/docker/README.md
@@ -1,7 +1,7 @@
 # LAUNCH UPDATE-SERVER
 
 ```$shell
-$docker-compose up
+$docker compose up
 ```
 
 # DATA

--- a/src/main/kotlin/org/eclipse/hara/ddiclient/api/actors/ActionManager.kt
+++ b/src/main/kotlin/org/eclipse/hara/ddiclient/api/actors/ActionManager.kt
@@ -79,7 +79,7 @@ private constructor(scope: ActorScope) : AbstractActor(scope) {
                 LOG.warn("ErrMsg. Not yet implemented")
             }
 
-            else -> unhandled(msg)
+            else -> handleMsgDefault(msg)
         }
     }
 

--- a/src/main/kotlin/org/eclipse/hara/ddiclient/api/actors/DeploymentManager.kt
+++ b/src/main/kotlin/org/eclipse/hara/ddiclient/api/actors/DeploymentManager.kt
@@ -36,7 +36,7 @@ private constructor(scope: ActorScope) : AbstractActor(scope) {
                 stopUpdateAndNotify(msg)
             }
 
-            else -> unhandled(msg)
+            else -> handleMsgDefault(msg)
         }
     }
 
@@ -61,7 +61,7 @@ private constructor(scope: ActorScope) : AbstractActor(scope) {
             is CancelForced -> {
                 stopUpdate()
             }
-            else -> unhandled(msg)
+            else -> handleMsgDefault(msg)
         }
     }
 
@@ -95,7 +95,7 @@ private constructor(scope: ActorScope) : AbstractActor(scope) {
             is CancelForced -> {
                 LOG.info("Force cancel ignored")
             }
-            else -> unhandled(msg)
+            else -> handleMsgDefault(msg)
         }
     }
 

--- a/src/main/kotlin/org/eclipse/hara/ddiclient/api/actors/DownloadManager.kt
+++ b/src/main/kotlin/org/eclipse/hara/ddiclient/api/actors/DownloadManager.kt
@@ -72,7 +72,7 @@ private constructor(scope: ActorScope) : AbstractActor(scope) {
                 }
             }
 
-            else -> unhandled(msg)
+            else -> handleMsgDefault(msg)
         }
     }
 
@@ -196,7 +196,7 @@ private constructor(scope: ActorScope) : AbstractActor(scope) {
                 stopUpdate()
             }
 
-            else -> unhandled(msg)
+            else -> handleMsgDefault(msg)
         }
     }
 
@@ -221,7 +221,7 @@ private constructor(scope: ActorScope) : AbstractActor(scope) {
                     Status.ERROR, "Failed to download file with md5 ${msg.md5} due to ${msg.message}", msg.message)
             }
 
-            else -> unhandled(msg)
+            else -> handleMsgDefault(msg)
         }
     }
 
@@ -321,12 +321,6 @@ private constructor(scope: ActorScope) : AbstractActor(scope) {
                         LOG.info("Removing artifacts of update with action id ${it.name}")
                         it.deleteRecursively() }
         }
-    }
-
-    //todo remove FileDownloader.Companion.Message.Stop message and use default implementation of beforeCloseChannel
-    @OptIn(ExperimentalCoroutinesApi::class)
-    override fun beforeCloseChannel() {
-        forEachActorNode { actorRef -> if(!actorRef.isClosedForSend) launch { actorRef.send(FileDownloader.Companion.Message.Stop) } }
     }
 
     init {

--- a/src/main/kotlin/org/eclipse/hara/ddiclient/api/actors/NotificationManager.kt
+++ b/src/main/kotlin/org/eclipse/hara/ddiclient/api/actors/NotificationManager.kt
@@ -25,7 +25,7 @@ private constructor(scope: ActorScope) : AbstractActor(scope) {
 
             is MessageListener.Message -> listeners.forEach { it.onMessage(msg) }
 
-            else -> unhandled(msg)
+            else -> handleMsgDefault(msg)
         }
     }
 

--- a/src/main/kotlin/org/eclipse/hara/ddiclient/api/actors/RootActor.kt
+++ b/src/main/kotlin/org/eclipse/hara/ddiclient/api/actors/RootActor.kt
@@ -23,12 +23,7 @@ private constructor(scope: ActorScope) : AbstractActor(scope) {
         when (msg) {
             is In.Start, In.ForcePing -> child("connectionManager")!!.send(msg)
 
-            is In.Stop -> {
-                child("connectionManager")!!.send(msg)
-                channel.close()
-            }
-
-            else -> unhandled(msg)
+            else -> handleMsgDefault(msg)
         }
     }
 

--- a/src/main/kotlin/org/eclipse/hara/ddiclient/api/actors/UpdateManager.kt
+++ b/src/main/kotlin/org/eclipse/hara/ddiclient/api/actors/UpdateManager.kt
@@ -62,7 +62,7 @@ private constructor(scope: ActorScope) : AbstractActor(scope) {
                 LOG.info(message)
             }
 
-            else -> unhandled(msg)
+            else -> handleMsgDefault(msg)
         }
     }
 
@@ -89,7 +89,7 @@ private constructor(scope: ActorScope) : AbstractActor(scope) {
                 stopUpdate()
             }
 
-            else -> unhandled(msg)
+            else -> handleMsgDefault(msg)
         }
     }
 
@@ -146,7 +146,7 @@ private constructor(scope: ActorScope) : AbstractActor(scope) {
                 sendFeedback(msg.info.id, closed, Progress(0,0), success,
                     "No update applied"
                 )
-                notificationManager.send(MessageListener.Message.Event.NoUpdate)
+                notificationManager.sendMessageToChannelIfOpen(MessageListener.Message.Event.NoUpdate)
             }
 
             updaterError.isNotEmpty() -> {
@@ -154,14 +154,14 @@ private constructor(scope: ActorScope) : AbstractActor(scope) {
                 parent!!.send(DeploymentManager.Companion.Message.UpdateFailed)
                 sendFeedback(msg.info.id, closed, Progress(updaters.size, updaterError[0].first),
                     failure, *details.toTypedArray())
-                notificationManager.send(MessageListener.Message.Event.UpdateFinished(successApply = false, details = details))
+                notificationManager.sendMessageToChannelIfOpen(MessageListener.Message.Event.UpdateFinished(successApply = false, details = details))
             }
 
             else -> {
                 parent!!.send(DeploymentManager.Companion.Message.UpdateFinished)
                 sendFeedback(msg.info.id, closed, Progress(updaters.size, updaters.size),
                     success, *details.toTypedArray())
-                notificationManager.send(MessageListener.Message.Event.UpdateFinished(successApply = true, details = details))
+                notificationManager.sendMessageToChannelIfOpen(MessageListener.Message.Event.UpdateFinished(successApply = true, details = details))
             }
         }
     }
@@ -201,7 +201,7 @@ private constructor(scope: ActorScope) : AbstractActor(scope) {
             vararg messages: String
     ) {
         val request = DeploymentFeedbackRequest.newInstance(id, execution, progress, finished, *messages)
-        connectionManager.send(DeploymentFeedback(request))
+        connectionManager.sendMessageToChannelIfOpen(DeploymentFeedback(request))
     }
 
     private fun convert(swModule: Updater.SwModule, pathCalculator: (Updater.SwModule.Artifact) -> String): Updater.SwModuleWithPath =
@@ -225,7 +225,7 @@ private constructor(scope: ActorScope) : AbstractActor(scope) {
     private suspend fun stopUpdate() {
         LOG.info("Stopping update")
         channel.cancel()
-        notificationManager.send(MessageListener.Message.State.CancellingUpdate)
+        notificationManager.sendMessageToChannelIfOpen(MessageListener.Message.State.CancellingUpdate)
         parent!!.send(ActionManager.Companion.Message.UpdateStopped)
     }
 

--- a/src/test/kotlin/org/eclipse/hara/ddiclient/integrationtest/HaraClientStoppingTest.kt
+++ b/src/test/kotlin/org/eclipse/hara/ddiclient/integrationtest/HaraClientStoppingTest.kt
@@ -1,0 +1,277 @@
+/*
+ *
+ *  * Copyright © 2017-2024  Kynetics  LLC
+ *  *
+ *  * This program and the accompanying materials are made
+ *  * available under the terms of the Eclipse Public License 2.0
+ *  * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *  *
+ *  * SPDX-License-Identifier: EPL-2.0
+ *
+ */
+package org.eclipse.hara.ddiclient.integrationtest
+
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.CoroutineStart
+import kotlinx.coroutines.Deferred
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.async
+import kotlinx.coroutines.channels.BufferOverflow
+import kotlinx.coroutines.channels.Channel
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.isActive
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.runBlocking
+import org.eclipse.hara.ddiclient.api.DownloadBehavior
+import org.eclipse.hara.ddiclient.api.HaraClient
+import org.eclipse.hara.ddiclient.api.MessageListener
+import org.eclipse.hara.ddiclient.api.Updater
+import org.eclipse.hara.ddiclient.integrationtest.abstractions.AbstractHaraMessageTest.ExpectedMessage
+import org.eclipse.hara.ddiclient.integrationtest.abstractions.AbstractTest
+import org.eclipse.hara.ddiclient.integrationtest.api.management.AssignDistributionType
+import org.eclipse.hara.ddiclient.integrationtest.api.management.HawkbitAssignDistributionBody
+import org.eclipse.hara.ddiclient.integrationtest.utils.TestUtils
+import org.eclipse.hara.ddiclient.integrationtest.utils.internalLog
+import org.eclipse.hara.ddiclient.integrationtest.utils.logCurrentFunctionName
+import org.testng.annotations.AfterClass
+import org.testng.annotations.Test
+import kotlin.coroutines.cancellation.CancellationException
+
+class HaraClientStoppingTest : AbstractTest() {
+
+   companion object {
+      const val TARGET_ID = "HaraClientStoppingTest"
+   }
+
+   private val testScope = CoroutineScope(Dispatchers.Default)
+   private var haraScope = CoroutineScope(Dispatchers.Default)
+
+   private val fiveSecondsDelayDownloadBehavior = object : DownloadBehavior {
+      override fun onAttempt(attempt: Int, artifactId: String,
+                             previousError: Throwable?): DownloadBehavior.Try {
+         return DownloadBehavior.Try.After(5)
+      }
+   }
+
+   private fun createMessageListener(channel: Channel<ExpectedMessage>): MessageListener {
+      return object : MessageListener {
+         override fun onMessage(message: MessageListener.Message) {
+            runBlocking {
+               "Received message: $message".internalLog()
+               channel.send(ExpectedMessage.HaraMessage(message))
+            }
+         }
+      }
+   }
+
+
+   @AfterClass
+   override fun afterTest() {
+      super.afterTest()
+      setPollingTime("00:00:10")
+   }
+
+   @Test(enabled = true, priority = 41, timeOut = 45_000, invocationCount = 1)
+   fun haraClientShouldStopPollingAfterBeingStoppedInDownloadingState() {
+      logCurrentFunctionName()
+      stoppingHaraClientWhileInDownloadingStateTestTemplate(TestUtils.OS_DISTRIBUTION_ID)
+   }
+
+   @Test(enabled = true, priority = 42, timeOut = 45_000, invocationCount = 1)
+   fun haraClientShouldStopPollingAfterBeingStoppedInDownloadingStateForMultipleArtifacts() {
+      logCurrentFunctionName()
+      stoppingHaraClientWhileInDownloadingStateTestTemplate(
+         TestUtils.OS_WITH_APPS_DISTRIBUTION_ID)
+   }
+
+   @Test(enabled = true, priority = 43, timeOut = 60_000, invocationCount = 1)
+   fun haraClientShouldStopPollingAfterBeingStoppedInUpdatingState() {
+      logCurrentFunctionName()
+      runTest { testJob ->
+         setPollingTime("00:00:05")
+         val expectedMessageChannel = Channel<ExpectedMessage>(5, BufferOverflow.DROP_OLDEST)
+
+         val updater = object : Updater {
+            override fun apply(modules: Set<Updater.SwModuleWithPath>,
+                               messenger: Updater.Messenger): Updater.UpdateResult {
+               haraScope.launch {
+                  "Applying long running fake update (8 sec) for modules: $modules".internalLog()
+                  delay(8_000)
+                  "Update applied".internalLog()
+                  messenger.sendMessageToServer("Update applied")
+               }
+               return Updater.UpdateResult(true)
+            }
+         }
+
+         haraClientStopTestTemplate(
+            updater = updater,
+            expectedMessageChannel = expectedMessageChannel,
+         ) { msg, testClient ->
+            if (msg is MessageListener.Message.State.Updating) {
+               testClient.stop()
+               "Client stopped".internalLog()
+               runBlockWhileEnsuringPollingIsNotDetected(
+                  expectedMessageChannel = expectedMessageChannel) {
+                  "waiting for 10 seconds to ensure that updating and polling is stopped".internalLog()
+                  delay(10_000) // wait for update to finish
+                  testJob?.cancel()
+               }
+            }
+         }
+      }
+   }
+
+   @Test(enabled = true, priority = 44, timeOut = 45_000, invocationCount = 1)
+   fun haraClientShouldPollAfterRestartedInDownloadingState() {
+      logCurrentFunctionName()
+      runTest { testJob ->
+
+         setPollingTime("00:00:10")
+         reCreateTestTargetOnServer(TARGET_ID)
+         assignHeavyOTAUpdateToTheTarget(TestUtils.OS_DISTRIBUTION_ID)
+
+         val expectedMessage = mutableListOf<ExpectedMessage.HaraMessage>()
+         val expectedMessageChannel = Channel<ExpectedMessage>(5, BufferOverflow.DROP_OLDEST)
+
+         var testClient = createClient(
+            expectedMessageChannel, downloadBehavior = fiveSecondsDelayDownloadBehavior)
+
+         testClient.startAsync()
+
+         listenToMessages(expectedMessageChannel, testClient) { msg, _ ->
+            if (expectedMessage.isNotEmpty()) {
+               assertEquals(msg, expectedMessage.removeFirst().message)
+               testJob?.cancel()
+            } else if (msg is MessageListener.Message.Event.StartDownloadFile) {
+               testClient.stop()
+               "Client stopped".internalLog()
+               delay(2_000)
+               // The client should start polling after restarting the HaraClient
+               testClient = createClient(expectedMessageChannel)
+               expectedMessage.add(
+                  ExpectedMessage.HaraMessage(MessageListener.Message.Event.Polling))
+               testClient.startAsync()
+            }
+         }
+      }
+   }
+
+   private fun stoppingHaraClientWhileInDownloadingStateTestTemplate(distributionId: Int) {
+      runTest { testJob ->
+         setPollingTime("00:00:05")
+         val expectedMessageChannel = Channel<ExpectedMessage>(5, BufferOverflow.DROP_OLDEST)
+
+         haraClientStopTestTemplate(
+            downloadBehavior = fiveSecondsDelayDownloadBehavior,
+            expectedMessageChannel = expectedMessageChannel,
+            distributionId = distributionId
+         ) { msg, testClient ->
+            if (msg is MessageListener.Message.Event.StartDownloadFile) {
+               testClient.stop()
+               "Client stopped".internalLog()
+               runBlockWhileEnsuringPollingIsNotDetected(
+                  expectedMessageChannel = expectedMessageChannel) {
+                  "waiting for 10 seconds to ensure that download and polling is stopped".internalLog()
+                  delay(10_000)
+                  testJob?.cancel()
+               }
+            }
+         }
+      }
+   }
+
+   private suspend fun haraClientStopTestTemplate(
+      downloadBehavior: DownloadBehavior = TestUtils.downloadBehavior,
+      expectedMessageChannel: Channel<ExpectedMessage> =
+         Channel(5, BufferOverflow.DROP_OLDEST),
+      updater: Updater = TestUtils.updater,
+      distributionId: Int = TestUtils.OS_DISTRIBUTION_ID,
+      onMessageReceive: suspend (MessageListener.Message, HaraClient) -> Unit
+   ) {
+
+      reCreateTestTargetOnServer(TARGET_ID)
+      assignHeavyOTAUpdateToTheTarget(distributionId)
+
+      val client = createClient(
+         expectedMessageChannel, downloadBehavior = downloadBehavior, updater = updater)
+
+      client.startAsync()
+
+      listenToMessages(expectedMessageChannel, client, onMessageReceive)
+   }
+
+   private suspend fun listenToMessages(
+      expectedMessageChannel: Channel<ExpectedMessage>,
+      client: HaraClient,
+      onMessageReceive: suspend (MessageListener.Message, HaraClient) -> Unit) {
+      for (msg in expectedMessageChannel) {
+         if (msg is ExpectedMessage.HaraMessage) {
+            onMessageReceive(msg.message, client)
+         }
+      }
+   }
+
+   private fun runTest(testBlock: suspend (Deferred<Unit>?) -> Unit) {
+      runBlocking {
+         try {
+            var testJob: Deferred<Unit>? = null
+            testJob = testScope.async(start = CoroutineStart.LAZY) {
+               launch {
+                  // Catching exceptions in haraClient scope by checking if it is still active
+                  while (haraScope.isActive) {
+                     delay(100)
+                  }
+                  throw RuntimeException(
+                     "Test failed: HaraClient scope is closed before the test is finished")
+               }
+               testBlock(testJob)
+            }
+            testJob.await()
+         } catch (ignored: CancellationException) {
+         }
+      }
+   }
+
+   private suspend fun runBlockWhileEnsuringPollingIsNotDetected(
+      delay: Long = 1_000,
+      expectedMessageChannel: Channel<ExpectedMessage>,
+      block: suspend () -> Unit) {
+      testScope.launch {
+         block()
+      }
+      val job = testScope.async {
+         delay(delay)
+         for (msg in expectedMessageChannel) {
+            if (msg is ExpectedMessage.HaraMessage && msg.message is MessageListener.Message.Event.Polling) {
+               throw IllegalStateException(
+                  "Test failed: Client is polling after being stopped")
+            }
+         }
+      }
+      try {
+         job.await()
+      } catch (ignored: CancellationException) {
+      }
+   }
+
+   private fun createClient(
+      expectedMessageChannel: Channel<ExpectedMessage>,
+      downloadBehavior: DownloadBehavior = TestUtils.downloadBehavior,
+      updater: Updater = TestUtils.updater): HaraClient {
+      val messageListener = createMessageListener(expectedMessageChannel)
+      haraScope = CoroutineScope(Dispatchers.Default)
+      return clientFromTargetId(
+         downloadBehavior = downloadBehavior, updater = updater,
+         messageListeners = listOf(messageListener),
+         scope = haraScope).invoke(TARGET_ID)
+   }
+
+   private suspend fun assignHeavyOTAUpdateToTheTarget(
+      distributionId: Int) {
+      val distribution = HawkbitAssignDistributionBody(
+         distributionId, AssignDistributionType.FORCED, 0)
+      assignDistributionToTheTarget(TARGET_ID, distribution)
+   }
+
+}

--- a/src/test/kotlin/org/eclipse/hara/ddiclient/integrationtest/abstractions/AbstractHaraMessageTest.kt
+++ b/src/test/kotlin/org/eclipse/hara/ddiclient/integrationtest/abstractions/AbstractHaraMessageTest.kt
@@ -114,13 +114,14 @@ abstract class AbstractHaraMessageTest : AbstractTest() {
         downloadBehavior: DownloadBehavior,
         okHttpClientBuilder: OkHttpClient.Builder,
         targetToken: String?,
-        gatewayToken: String?): (String) -> HaraClient {
+        gatewayToken: String?,
+        scope: CoroutineScope): (String) -> HaraClient {
         return super.clientFromTargetId(
             directoryDataProvider, configDataProvider, updater,
             listOf(messageListener),
             deploymentPermitProvider,
             downloadBehavior, okHttpClientBuilder,
-            targetToken, gatewayToken)
+            targetToken, gatewayToken, scope)
     }
 
     protected fun expectMessages(vararg messages: MessageListener.Message) {


### PR DESCRIPTION
This commit fixes the crash when haraClient is stopped during the Downloading/Updating state. 
The crash occurred because all created actors were not closed properly.
Reported in #54 
Also added unit tests related to the applied fix to ensure it's consistency.