### PR TITLE
Remove additional polling while installing updates

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -292,6 +292,7 @@ test {
     systemProperty("LOG_HTTP", project.findProperty("logHttp") ?: "false")
     systemProperty("LOG_INTERNAL", project.findProperty("logInternal") ?: "false")
     systemProperty("BACKOFF_INTERVAL_SECONDS", 45)
+    systemProperty("FREQUENT_POLLING_WHILE_UPDATING", false)
 
     dependsOn ':virtual-device:test'
 


### PR DESCRIPTION
Upon receiving a new deployment, the client starts to poll the server every 30 seconds (Hardcoded value)
This commit removes this additional polling.